### PR TITLE
Replaced deprecated asyncio.async with asyncio.ensure_future

### DIFF
--- a/aiomanhole/__init__.py
+++ b/aiomanhole/__init__.py
@@ -234,7 +234,7 @@ class InterpreterFactory:
             namespace=self.namespace if self.shared else dict(self.namespace),
             **self.kwargs
         )
-        return asyncio.async(interpreter(reader, writer), loop=self.loop)
+        return asyncio.ensure_future(interpreter(reader, writer), loop=self.loop)
 
 
 def start_manhole(banner=None, host='127.0.0.1', port=None, path=None,


### PR DESCRIPTION
`asyncio.async` is deprecated since Python version 3.4.4 (https://docs.python.org/3.7/library/asyncio-task.html#asyncio.async) and dropped in version 3.7 (https://bugs.python.org/issue32272)