### PR TITLE
Pass loop to ensure_future when starting a unix domain socket.

### DIFF
--- a/aiomanhole/__init__.py
+++ b/aiomanhole/__init__.py
@@ -278,10 +278,10 @@ def start_manhole(banner=None, host='127.0.0.1', port=None, path=None,
 
     if path:
         f = asyncio.ensure_future(
-            asyncio.start_unix_server(client_cb, path=path, loop=loop))
+            asyncio.start_unix_server(client_cb, path=path, loop=loop), loop=loop)
         coros.append(f)
 
-    if port:
+    if port is not None:
         f = asyncio.ensure_future(asyncio.start_server(
             client_cb, host=host, port=port, loop=loop), loop=loop)
         coros.append(f)


### PR DESCRIPTION
Fixes a small bug where starting a server on a unix domain socket uses the global loop.

Adds test coverage for start_server, and changes the test coverage to remove the global loop.

In support of the test coverage, adds the ability to bind to port 0.